### PR TITLE
Don't require the os_password parameter

### DIFF
--- a/ocf/neutron-ha-tool
+++ b/ocf/neutron-ha-tool
@@ -116,7 +116,7 @@ The region name to use for authentication against keystone.
 <content type="string" default="${OCF_RESKEY_os_region_name_default}" />
 </parameter>
 
-<parameter name="os_password" unique="0" required="1">
+<parameter name="os_password" unique="0" required="0">
 <longdesc lang="en">
 The password to use for authentication against keystone.
 </longdesc>


### PR DESCRIPTION
Do not require the os_password parameter. It is delivered in a
separate file

(cherry picked from commit 47a336735693f8c9459850cd78ab089944c87102)
